### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,7 +19,7 @@ class action_plugin_geonav extends DokuWiki_Action_Plugin {
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'geonav_hookjs');
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -57,7 +57,7 @@ class syntax_plugin_geonav extends DokuWiki_Syntax_Plugin {
   /**
    * Handle the match
    */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
       parse_str($match, $return);   
       return $return;
   }
@@ -65,7 +65,7 @@ class syntax_plugin_geonav extends DokuWiki_Syntax_Plugin {
   /**
    *  Render output
    */
-  function render($mode, &$R, $data) {
+  function render($mode, Doku_Renderer $R, $data) {
       global $INFO;
       global $conf;
       require_once(DOKU_PLUGIN.'geonav/lang/en/lang.php');


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
